### PR TITLE
helm chart job pod annotations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       uses: helm/kind-action@v1.1.0
       with:
         wait: 180s
+        verbosity: 100
       # Only build a kind cluster if there are chart changes to test.
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
     - name: Run chart-testing (install)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       uses: helm/kind-action@v1.1.0
       with:
         log_level: trace
+        node_image: kindest/node:v1.21.1
       # Only build a kind cluster if there are chart changes to test.
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
     - name: debug kind node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       # Only build a kind cluster if there are chart changes to test.
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
     - name: Run chart-testing (install)
-      run: ct install
+      run: ct install --debug
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     - name: gitLeaks
       uses: zricethezav/gitleaks-action@v1.3.0
     - name: Install chart-testing (lint)
-      uses: helm/chart-testing-action@v2.0.1
+      uses: helm/chart-testing-action@v2.1.0
     - name: Run chart-testing (list-changed)
       id: list-changed
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run chart-testing (lint)
       run: ct lint
     - name: Create kind cluster
-      uses: helm/kind-action@v1.11111111111.0
+      uses: helm/kind-action@v1.1.0
       # Only build a kind cluster if there are chart changes to test.
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
     - name: Run chart-testing (install)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,6 @@ jobs:
       uses: actions/checkout@v2
     - name: Fetch history
       run: git fetch --prune --unshallow
-    - name: gitLeaks
-      uses: zricethezav/gitleaks-action@v1.3.0
     - name: Install chart-testing (lint)
       uses: helm/chart-testing-action@v2.1.0
     - name: Run chart-testing (list-changed)
@@ -23,8 +21,6 @@ jobs:
         if [[ -n "$changed" ]]; then
           echo "::set-output name=changed::true"
         fi
-    - name: Run chart-testing (lint)
-      run: ct lint
     - name: Create kind cluster
       uses: helm/kind-action@v1.1.0
       with:
@@ -32,7 +28,7 @@ jobs:
       # Only build a kind cluster if there are chart changes to test.
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
     - name: debug kind node
-      run: docker logs kind-control-plane
+      run: docker ps -q && docker logs $(docker ps -q)
     - name: Run chart-testing (install)
       run: ct install --debug
       if: ${{ steps.list-changed.outputs.changed == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run chart-testing (lint)
       run: ct lint
     - name: Create kind cluster
-      uses: helm/kind-action@v1.0.0
+      uses: helm/kind-action@v1.11111111111.0
       # Only build a kind cluster if there are chart changes to test.
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
     - name: Run chart-testing (install)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,15 +21,11 @@ jobs:
         if [[ -n "$changed" ]]; then
           echo "::set-output name=changed::true"
         fi
-    - name: Create kind cluster
-      uses: helm/kind-action@v1.1.0
+    - uses: balchua/microk8s-actions@v0.2.1
       with:
-        log_level: trace
-        node_image: kindest/node:v1.19.11
-      # Only build a kind cluster if there are chart changes to test.
+        channel: '1.19/stable'
+        addons: '["dns", "rbac", "storage", "registry", "metrics-server"]'
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
-    - name: debug kind node
-      run: docker ps -q && docker logs $(docker ps -q)
     - name: Run chart-testing (install)
       run: ct install --debug
       if: ${{ steps.list-changed.outputs.changed == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       uses: helm/kind-action@v1.1.0
       with:
         wait: 180s
-        verbosity: 100
+        log_level: trace
       # Only build a kind cluster if there are chart changes to test.
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
     - name: Run chart-testing (install)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Fetch history
       run: git fetch --prune --unshallow
+    - name: gitLeaks
+      uses: zricethezav/gitleaks-action@v1.3.0
     - name: Install chart-testing (lint)
       uses: helm/chart-testing-action@v2.1.0
     - name: Run chart-testing (list-changed)
@@ -24,10 +26,10 @@ jobs:
     - uses: balchua/microk8s-actions@v0.2.1
       with:
         channel: '1.19/stable'
-        addons: '["dns", "rbac", "storage", "registry", "metrics-server"]'
+        addons: '["dns"]'
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
     - name: Run chart-testing (install)
-      run: ct install --debug
+      run: ct install
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       uses: helm/kind-action@v1.1.0
       with:
         log_level: trace
-        node_image: kindest/node:v1.21.1
+        node_image: kindest/node:v1.19.11
       # Only build a kind cluster if there are chart changes to test.
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
     - name: debug kind node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Set up Helm
+      uses: azure/setup-helm@v1
     - name: Fetch history
       run: git fetch --prune --unshallow
     - name: gitLeaks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Set up Helm
-      uses: azure/setup-helm@v1
     - name: Fetch history
       run: git fetch --prune --unshallow
     - name: gitLeaks
@@ -30,10 +28,11 @@ jobs:
     - name: Create kind cluster
       uses: helm/kind-action@v1.1.0
       with:
-        wait: 180s
         log_level: trace
       # Only build a kind cluster if there are chart changes to test.
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
+    - name: debug kind node
+      run: docker logs kind-control-plane
     - name: Run chart-testing (install)
       run: ct install --debug
       if: ${{ steps.list-changed.outputs.changed == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
       run: ct lint
     - name: Create kind cluster
       uses: helm/kind-action@v1.1.0
+      with:
+        wait: 180s
       # Only build a kind cluster if there are chart changes to test.
       if: ${{ steps.list-changed.outputs.changed == 'true' }}
     - name: Run chart-testing (install)

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for Kubernetes
 type: application
-version: 0.5.26
+version: 0.5.27
 appVersion: 0.43.0
 
 home: https://lakefs.io

--- a/charts/lakefs/templates/job.yaml
+++ b/charts/lakefs/templates/job.yaml
@@ -17,7 +17,9 @@ spec:
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-
+      {{- with .Values.jobPodAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       restartPolicy: Never
       containers:

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -26,6 +26,7 @@ ingress:
 
 
 podAnnotations: {}
+jobPodAnnotations: {}
 
 deployment:
   port: 8000

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -26,7 +26,8 @@ ingress:
 
 
 podAnnotations: {}
-jobPodAnnotations: {}
+jobPodAnnotations:
+  sidecar.istio.io/inject: "false"
 
 deployment:
   port: 8000


### PR DESCRIPTION
This is a workaround for #74.
Allows adding custom annotation to the migration pod. Will allow the user to add `sidecar.istio.io/inject: false` to disable istio on the migration pod.

More info: medium.com/redbox-techblog/handling-istio-sidecars-in-kubernetes-jobs-c392661c4af7
