### PR TITLE
Set blockstore.type when no config-file exists

### DIFF
--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for Kubernetes
 type: application
-version: 0.5.32
+version: 0.5.33
 appVersion: 0.47.0
 
 home: https://lakefs.io

--- a/charts/lakefs/templates/_env.tpl
+++ b/charts/lakefs/templates/_env.tpl
@@ -18,6 +18,8 @@ env:
     value: asdjfhjaskdhuioaweyuiorasdsjbaskcbkj
   {{- end }}
   {{- if not .Values.lakefsConfig }}
+  - name: LAKEFS_BLOCKSTORE_TYPE
+    value: local
   - name: LAKEFS_BLOCKSTORE_LOCAL_PATH
     value: /lakefs/data
   {{- end }}


### PR DESCRIPTION
Part of fixing treeverse/lakefs#2363: blockstore.type will be required once
we fix that!