### PR TITLE
Bugfix - committedLocalCacheVolume env is missing dash

### DIFF
--- a/charts/lakefs/templates/_env.tpl
+++ b/charts/lakefs/templates/_env.tpl
@@ -28,7 +28,7 @@ env:
     value: http://localhost:7001
   {{- end }}
   {{- if .Values.committedLocalCacheVolume }}
-    name: LAKEFS_COMMITTED_LOCAL_CACHE_DIR
+  - name: LAKEFS_COMMITTED_LOCAL_CACHE_DIR
     value: /lakefs/cache
   {{- end }}
 {{- if .Values.extraEnvVarsSecret }}


### PR DESCRIPTION
Fix the following bug when enabling committedLocalCacheVolume : 

In batch/v1/Job lakefs
```
error validating data: ValidationError(Job.spec.template.spec.containers[0].env): invalid type for io.k8s.api.core.v1.Container.env: got "map", expected "array"
```

In apps/v1/Deployment lakefs
```
error validating data: ValidationError(Deployment.spec.template.spec.containers[0].env): invalid type for io.k8s.api.core.v1.Container.env: got "map", expected "array"
```