### PR TITLE
Support configure non postgres database

### DIFF
--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for Kubernetes
 type: application
-version: 0.6.10
+version: 0.7.0
 appVersion: 0.86.0
 
 home: https://lakefs.io

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for Kubernetes
 type: application
-version: 0.6.9
+version: 0.6.10
 appVersion: 0.86.0
 
 home: https://lakefs.io

--- a/charts/lakefs/README.md
+++ b/charts/lakefs/README.md
@@ -54,26 +54,31 @@ If you can't provide such access, lakeFS can be configured to use an AWS key-pai
 ## Notable Chart Upgrades
 
 ### Upgrading from chart version 0.5.XX or lower (lakeFS v0.70.XX or lower)
+
 Introducing [lakeFS v0.80.0](https://github.com/treeverse/lakeFS/releases/tag/v0.80.0), with **Key Value Store** support. As part of this upgrade, the entire database will be ported to the new KV.
 Before performing this upgrade, it is strongly recommended to perform these steps:
 * Commit all uncommitted data on branches
 * Create a snapshot of your database
 
 In order to prevent loss of data during this process it is recommended to stop all the pods running `lakeFS`. This can be achieved by scaling the number of pods down to 0:
+
 ```bash
 # Stopping all pods running release my-lakefs
 kubectl scale --replicas=0 deployment my-lakefs
 ```
 
 Once all `lakeFS` pods are stopped, you can upgrade using the `upgrade` command
+
 ```bash
 # Upgrade lakeFS to the latest helm release
 helm upgrade -f my-values.yaml my-lakefs lakefs/lakefs --set kv_upgrade=true
 ```
+
 **Please note the `kv_upgrade` flag, which is required for this upgrade** (It is not required for a fresh installation of `lakeFS` with KV)
 
 
 ## Configurations
+
 | **Parameter**                               | **Description**                                                                                                | **Default** |
 |---------------------------------------------|----------------------------------------------------------------------------------------------------------------|-------------|
 | `secrets.databaseConnectionString`          | PostgreSQL connection string to be used by lakeFS                                                              |             |

--- a/charts/lakefs/README.md
+++ b/charts/lakefs/README.md
@@ -74,18 +74,19 @@ helm upgrade -f my-values.yaml my-lakefs lakefs/lakefs --set kv_upgrade=true
 
 
 ## Configurations
-| **Parameter**                               | **Description**                                                                                            | **Default** |
-|---------------------------------------------|------------------------------------------------------------------------------------------------------------|-------------|
-|`secrets.databaseConnectionString`|PostgreSQL connection string to be used by lakeFS||
-|`secrets.authEncryptSecretKey`|A random (cryptographically safe) generated string that is used for encryption and HMAC signing||
-| `lakefsConfig`                              | lakeFS config YAML stringified, as shown above. See [reference](https://docs.lakefs.io/reference/configuration.html) for available configurations.                                                               |             |
-| `replicaCount`                              | Number of lakeFS pods                                                                                      | `1`         |
-| `resources`                                 | Pod resource requests & limits                                                                             | `{}`        |
-| `service.type`                              | Kuberenetes service type                                                                                   | ClusterIP   |
-| `service.port`                              | Kubernetes service external port                                                                           | 80          |
-| `extraEnvVars`                        | Adds additional environment variables to the deployment (in yaml syntax) | `{}` See [values.yaml](values.yaml) |
-| `extraEnvVarsSecret`                        | Name of a Kubernetes secret containing extra environment variables |
-| `s3Fallback.enabled`                            | If set to true, an [S3Proxy](https://github.com/gaul/s3proxy) container will be started. Requests to lakeFS S3 gateway with a non-existing repository will be forwarded to this container.
-| `s3Fallback.aws_access_key` | An AWS access key to be used by the S3Proxy for authentication |
-| `s3Fallback.aws_secret_key` | An AWS secret key to be used by the S3Proxy for authentication |
-| `committedLocalCacheVolume` | A volume definition to be mounted by lakeFS and used for caching committed metadata. See [here](https://kubernetes.io/docs/concepts/storage/volumes/#volume-types) for a list of supported volume types. The default values.yaml file shows an example of how to use this parameter. |
+| **Parameter**                               | **Description**                                                                                                | **Default** |
+|---------------------------------------------|----------------------------------------------------------------------------------------------------------------|-------------|
+| `secrets.databaseConnectionString`          | PostgreSQL connection string to be used by lakeFS                                                              |             |
+| `secrets.authEncryptSecretKey`              | A random (cryptographically safe) generated string that is used for encryption and HMAC signing                |             |
+| `lakefsConfig`                              | lakeFS config YAML stringified, as shown above. See [reference](https://docs.lakefs.io/reference/configuration.html) for available configurations. |             |
+| `replicaCount`                              | Number of lakeFS pods                                                                                          | `1`         |
+| `resources`                                 | Pod resource requests & limits                                                                                 | `{}`        |
+| `service.type`                              | Kuberenetes service type                                                                                       | ClusterIP   |
+| `service.port`                              | Kubernetes service external port                                                                               | 80          |
+| `extraEnvVars`                              | Adds additional environment variables to the deployment (in yaml syntax) | `{}` See [values.yaml](values.yaml) |
+| `extraEnvVarsSecret`                        | Name of a Kubernetes secret containing extra environment variables                                             |
+| `s3Fallback.enabled`                        | If set to true, an [S3Proxy](https://github.com/gaul/s3proxy) container will be started. Requests to lakeFS S3 gateway with a non-existing repository will be forwarded to this container.
+| `s3Fallback.aws_access_key`                 | An AWS access key to be used by the S3Proxy for authentication                                                 |
+| `s3Fallback.aws_secret_key`                 | An AWS secret key to be used by the S3Proxy for authentication                                                 |
+| `committedLocalCacheVolume`                 | A volume definition to be mounted by lakeFS and used for caching committed metadata. See [here](https://kubernetes.io/docs/concepts/storage/volumes/#volume-types) for a list of supported volume types. The default values.yaml file shows an example of how to use this parameter. |
+

--- a/charts/lakefs/templates/NOTES.txt
+++ b/charts/lakefs/templates/NOTES.txt
@@ -11,7 +11,7 @@ Thank you for installing lakeFS!
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "lakefs.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}/setup
 {{- else if contains "ClusterIP"  .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "lakefs.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:{{ .Values.deployment.port }}/setup to use your application"
   kubectl port-forward $POD_NAME {{ .Values.deployment.port }}:{{ .Values.deployment.port }} --namespace {{ .Release.Namespace }}
 {{- end }}

--- a/charts/lakefs/templates/_env.tpl
+++ b/charts/lakefs/templates/_env.tpl
@@ -1,6 +1,6 @@
 {{- define "lakefs.env" -}}
 env:
-  {{- if .Values.secrets.databaseConnectionString }}
+  {{- if and (.Values.secrets) (.Values.secrets.databaseConnectionString) }}
   - name: LAKEFS_DATABASE_TYPE
     value: postgres
   - name: LAKEFS_DATABASE_POSTGRES_CONNECTION_STRING
@@ -13,12 +13,11 @@ env:
     value: postgres
   - name: LAKEFS_DATABASE_POSTGRES_CONNECTION_STRING
     value: postgres://postgres:password@localhost:5432/postgres?sslmode=disable
-  {{ - else if not .Values.lakefsConfig}}
+  {{- else if not .Values.lakefsConfig }}
   - name: LAKEFS_DATABASE_TYPE
     value: local
   {{- end }}
-
-  {{- if .Values.secrets.authEncryptSecretKey }}
+  {{- if and (.Values.secrets) (.Values.secrets.authEncryptSecretKey) }}
   - name: LAKEFS_AUTH_ENCRYPT_SECRET_KEY
     valueFrom:
       secretKeyRef:
@@ -28,7 +27,6 @@ env:
   - name: LAKEFS_AUTH_ENCRYPT_SECRET_KEY
     value: asdjfhjaskdhuioaweyuiorasdsjbaskcbkj
   {{- end }}
-
   {{- if not .Values.lakefsConfig }}
   - name: LAKEFS_BLOCKSTORE_TYPE
     value: local
@@ -55,13 +53,13 @@ envFrom:
 
 {{- define "lakefs.migrate.env" -}}
 {{ include "lakefs.env" . }}
-  {{- if .Values.secrets }}
+  {{- if and (.Values.secrets) (.Values.secrets.databaseConnectionString) }}
   - name: LAKEFS_DATABASE_CONNECTION_STRING
     valueFrom:
       secretKeyRef:
         name: {{ include "lakefs.fullname" . }}
         key: database_connection_string
-  {{- else if or (not .Values.lakefsConfig) .Values.localPostgres }}
+  {{- else if .Values.localPostgres }}
   - name: LAKEFS_DATABASE_CONNECTION_STRING
     value: postgres://postgres:password@localhost:5432/postgres?sslmode=disable
   {{- end}}

--- a/charts/lakefs/templates/_env.tpl
+++ b/charts/lakefs/templates/_env.tpl
@@ -1,24 +1,34 @@
 {{- define "lakefs.env" -}}
 env:
+  {{- if .Values.secrets.databaseConnectionString }}
   - name: LAKEFS_DATABASE_TYPE
     value: postgres
-  {{- if .Values.secrets }}
   - name: LAKEFS_DATABASE_POSTGRES_CONNECTION_STRING
     valueFrom:
       secretKeyRef:
         name: {{ include "lakefs.fullname" . }}
         key: database_connection_string
+  {{- else if .Values.localPostgres }}
+  - name: LAKEFS_DATABASE_TYPE
+    value: postgres
+  - name: LAKEFS_DATABASE_POSTGRES_CONNECTION_STRING
+    value: postgres://postgres:password@localhost:5432/postgres?sslmode=disable
+  {{ - else if not .Values.lakefsConfig}}
+  - name: LAKEFS_DATABASE_TYPE
+    value: local
+  {{- end }}
+
+  {{- if .Values.secrets.authEncryptSecretKey }}
   - name: LAKEFS_AUTH_ENCRYPT_SECRET_KEY
     valueFrom:
       secretKeyRef:
         name: {{ include "lakefs.fullname" . }}
         key: auth_encrypt_secret_key
-  {{- else if or (not .Values.lakefsConfig) .Values.localPostgres }}
-  - name: LAKEFS_DATABASE_POSTGRES_CONNECTION_STRING
-    value: postgres://postgres:password@localhost:5432/postgres?sslmode=disable
+  {{- else }}
   - name: LAKEFS_AUTH_ENCRYPT_SECRET_KEY
     value: asdjfhjaskdhuioaweyuiorasdsjbaskcbkj
   {{- end }}
+
   {{- if not .Values.lakefsConfig }}
   - name: LAKEFS_BLOCKSTORE_TYPE
     value: local

--- a/charts/lakefs/templates/secret.yaml
+++ b/charts/lakefs/templates/secret.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "lakefs.labels" . | nindent 4 }}
 type: Opaque
 data:
+{{- if .Values.secrets.databaseConnectionString }}
   database_connection_string: {{ .Values.secrets.databaseConnectionString | default "" | b64enc }}
+{{- end}}
   auth_encrypt_secret_key: {{ .Values.secrets.authEncryptSecretKey | default "" | b64enc }}
 {{- end}}


### PR DESCRIPTION
Fix #149 

Default still configure and spin postgres - consider using local as alternative in a different Issue/PR.
When database connection is configured - postgres database is set as type.
When setting `lakefsConfig` - the user should set `database.type` to dynamodb / postgres / local as needed.