### PR TITLE
Bump release chart and app v0.89.0

### DIFF
--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 0.8.3
-appVersion: 0.88.0
+version: 0.8.4
+appVersion: 0.89.0
 
 home: https://lakefs.io
 icon: https://lakefs.io/wp-content/uploads/2020/07/lake-fs-color-2.svg


### PR DESCRIPTION
Release: https://github.com/treeverse/lakeFS/releases/tag/v0.89.0 