### PR TITLE
Feature: Additional Resources support for Lakefs chart 

### DIFF
--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 0.8.11
-appVersion: 0.94.1
+version: 0.8.12
+appVersion: 0.94.2
 
 home: https://lakefs.io
 icon: https://lakefs.io/wp-content/uploads/2020/07/lake-fs-color-2.svg

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 0.8.12
+version: 0.9.0
 appVersion: 0.94.2
 
 home: https://lakefs.io

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -3,7 +3,7 @@ name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
 version: 0.9.0
-appVersion: 0.94.2
+appVersion: 0.95.0
 
 home: https://lakefs.io
 icon: https://lakefs.io/wp-content/uploads/2020/07/lake-fs-color-2.svg

--- a/charts/lakefs/templates/additional-resources.yaml
+++ b/charts/lakefs/templates/additional-resources.yaml
@@ -1,0 +1,7 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}
+
+
+

--- a/charts/lakefs/templates/ingress.yaml
+++ b/charts/lakefs/templates/ingress.yaml
@@ -55,5 +55,20 @@ spec:
               servicePort: {{ $svcPort }}
           {{- end }}
           {{- end }}
+          {{- range .pathsOverrides }}
+          - path: {{ .path }}
+          {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .serviceName }}
+                port: 
+                  number: {{ .servicePort }}
+          {{- else }} 
+            backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+          {{- end }}
+          {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -21,6 +21,11 @@ ingress:
   hosts:
     - host: chart-example.local
       paths: []
+      # redirect to a different service based on path prefix for advanced use cases only
+      # pathsOverrides: 
+      #   - path: /some/path
+      #     serviceName: other-example.local
+      #     servicePort: 80
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -22,7 +22,7 @@ ingress:
     - host: chart-example.local
       paths: []
       # redirect to a different service based on path prefix for advanced use cases only
-      # pathsOverrides: 
+      # pathsOverrides:
       #   - path: /some/path
       #     serviceName: other-example.local
       #     servicePort: 80


### PR DESCRIPTION
There are 2 changes in this PR, the goal is to enable different resources to be added into the chart of lakeFS (advanced use-cases). 

### 1. added `ingress.hosts[].pathsOverrides`: 

In `Ingress` resources we might want to redirect certain API paths of lakeFS to a different service: 

Usage Example in `values.yaml`:

```yaml 
ingress:
  hosts:
    - host: lakefs.company.com
      paths: 
       - /
      pathsOverrides: 
        - path: /auth/
          serviceName: remote-authenticator.svc
          servicePort: 80
``` 

### 2. Render additional resources 

Utilizing [Helm tpl](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function) we can render and reuse in `values.yaml`. 

Example, can be used the following way: 

```yaml
extraManifests:

  - apiVersion: v1
    kind: Service
    metadata:
      name: "{{ .Release.Name }}-watchdog"

  - apiVersion: apps/v1
    kind: Deployment
    metadata:
      name: "{{ .Release.Name }}-watchdog"
    spec:
      containers:
        image: "watchdog"
```