### PR TITLE
Bump Chart version up to 0.100.0

### DIFF
--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 0.9.4
-appVersion: 0.97.5
+version: 0.9.5
+appVersion: 0.100.0
 
 home: https://lakefs.io
 icon: https://lakefs.io/wp-content/uploads/2020/07/lake-fs-color-2.svg


### PR DESCRIPTION
Note that versions between 0.97.5 and this (0.100.0) appear missing.