### PR TITLE
Add nodePort to helm service.yaml

### DIFF
--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-
 version: 1.3.20
 appVersion: 1.43.0
 

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.3.19
+version: 1.3.20
 appVersion: 1.42.0
 
 home: https://lakefs.io

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-
 version: 1.3.17
 appVersion: 1.40.0
 

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.3.11
+version: 1.3.17
 appVersion: 1.35.0
 
 home: https://lakefs.io

--- a/charts/lakefs/templates/service.yaml
+++ b/charts/lakefs/templates/service.yaml
@@ -9,9 +9,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
-{{- if .Values.service.nodePort }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
       nodePort: {{ .Values.service.nodePort }}
-{{- end }}
+      {{- end }}
       protocol: TCP
       name: http
   selector:

--- a/charts/lakefs/templates/service.yaml
+++ b/charts/lakefs/templates/service.yaml
@@ -9,6 +9,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
+{{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+{{- end }}
       protocol: TCP
       name: http
   selector:


### PR DESCRIPTION
Adding nodePort to the service.yaml enables a static external port to access the LakeFS GUI.

This is good for smaller deployments and testing.