### PR TITLE
fix: allow annotations for service

### DIFF
--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.3.20
+version: 1.3.21
 appVersion: 1.43.0
 
 home: https://lakefs.io

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.3.19
+version: 1.3.20
 appVersion: 1.43.0
 
 home: https://lakefs.io

--- a/charts/lakefs/templates/service.yaml
+++ b/charts/lakefs/templates/service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "lakefs.fullname" . }}
   labels:
     {{- include "lakefs.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -40,6 +40,7 @@ deployment:
   port: 8000
 
 service:
+  annotations: {}
   type: ClusterIP
   port: 80
 


### PR DESCRIPTION
When you use an azure loadbalancer you need to be able to add an annotation on the service.