### PR TITLE
Add option to add additional labels to lakefs pod

### DIFF
--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.3.25
+version: 1.3.26
 appVersion: 1.45.0
 
 home: https://lakefs.io

--- a/charts/lakefs/templates/deployment.yaml
+++ b/charts/lakefs/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
     {{- end }}
       labels:
         {{- include "lakefs.selectorLabels" . | nindent 8 }}
+    {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
       serviceAccountName: {{ include "lakefs.serviceAccountName" . }}
       securityContext:

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -32,7 +32,12 @@ ingress:
   #      - chart-example.local
 
 
+# Extra annotations to add to the pod
 podAnnotations: {}
+
+# Extra labels to add to the pod
+podLabels: {}
+
 jobPodAnnotations:
   sidecar.istio.io/inject: "false"
 


### PR DESCRIPTION
In certain cases you want to override the pod labels.
example : adding azure.workload.identity/use=true  in https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels

this pr adds the option to specify labels