### PR TITLE
Use lakefs-enterprise in lakefs charts

### DIFF
--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.3.32
-appVersion: 1.49.0
+version: 1.3.34
+appVersion: 1.49.1
 
 home: https://lakefs.io
 icon: https://lakefs.io/wp-content/uploads/2020/07/lake-fs-color-2.svg

--- a/charts/lakefs/templates/_helpers.tpl
+++ b/charts/lakefs/templates/_helpers.tpl
@@ -62,3 +62,21 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define which repository to use according to the following:
+1. Explicitly defined
+2. Otherwise if fluffy is enabled - take enterprise image
+3. Otherwise use OSS image
+*/}}
+{{- define "lakefs.repository" -}}
+{{- if not .Values.image.repository }}
+{{- if (.Values.fluffy).enabled  }}
+{{- default "treeverse/lakefs-enterprise" .Values.image.repository }}
+{{- else }}
+{{- default "treeverse/lakefs" .Values.image.repository }}
+{{- end }}
+{{- else }}
+{{- default .Values.image.repository }}
+{{- end }}
+{{- end }}

--- a/charts/lakefs/templates/deployment.yaml
+++ b/charts/lakefs/templates/deployment.yaml
@@ -19,6 +19,16 @@ spec:
       labels:
         {{- include "lakefs.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if (.Values.fluffy).enabled }}
+       {{- if (.Values.fluffy.image.privateRegistry).enabled }}
+      imagePullSecrets:
+        {{- if (.Values.fluffy.image.privateRegistry).secretToken }}
+        - name: "docker-registry"
+        {{- else }}
+        - name: {{ .Values.fluffy.image.privateRegistry.secretName }}
+        {{- end }}
+       {{- end }}
+      {{- end }}
       serviceAccountName: {{ include "lakefs.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -31,7 +41,11 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if (.Values.fluffy).enabled }}
+          image: "treeverse/lakefs-enterprise:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- else}}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/lakefs/templates/deployment.yaml
+++ b/charts/lakefs/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       labels:
         {{- include "lakefs.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if eq ( include "lakefs.fullname" .) "treeverse/lakefs-enterprise" }}
+      {{- if eq ( include "lakefs.repository" .) "treeverse/lakefs-enterprise" }}
        {{- if (.Values.fluffy.image.privateRegistry).enabled }}
       imagePullSecrets:
         {{- if (.Values.fluffy.image.privateRegistry).secretToken }}

--- a/charts/lakefs/templates/deployment.yaml
+++ b/charts/lakefs/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       labels:
         {{- include "lakefs.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if (.Values.fluffy).enabled }}
+      {{- if eq ( include "lakefs.fullname" .) "treeverse/lakefs-enterprise" }}
        {{- if (.Values.fluffy.image.privateRegistry).enabled }}
       imagePullSecrets:
         {{- if (.Values.fluffy.image.privateRegistry).secretToken }}
@@ -41,11 +41,7 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if (.Values.fluffy).enabled }}
-          image: "treeverse/lakefs-enterprise:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          {{- else}}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          {{- end }}
+          image: "{{ include "lakefs.repository" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -5,7 +5,6 @@
 replicaCount: 1
 
 image:
-  repository: treeverse/lakefs
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
closes #313 

When fluffy is enabled use lakefs-enterprise image instead of OSS

@idanovo @Isan-Rivkin Not sure if the changes I made are the "right" way to do it. Let me know if this can be done better.

Tested manually