### PR TITLE
Remove MDS image tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.8.0
+:new: What's new:
+- Remove image tag from mds (will take latest tag)
+
 # 1.7.22
 :new: What's new:
 - Update lakeFS version to [1.79.0](https://github.com/treeverse/lakeFS/releases/tag/v1.79.0)

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.7.22
+version: 1.8.0
 appVersion: 1.79.0
 
 home: https://lakefs.io

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -114,7 +114,6 @@ mds:
   image:
     pullPolicy: IfNotPresent
     repository: treeverse/mds
-    tag: "0.2.1"
   extraEnvVars: {}
   resources:
     # limits:


### PR DESCRIPTION
By default, chart will try to take latest tag for mds