### PR TITLE
Decouple community and enterprise image tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.9.0
+:new: What's new:
+- Decouple lakeFS image tag from `Chart.AppVersion`: select community or enterprise tag via `image.community.tag` / `image.enterprise.tag` based on the `enterprise.enabled` flag
+
 # 1.8.1
 :new: What's new:
 - Update lakeFS version to [1.80.0](https://github.com/treeverse/lakeFS/releases/tag/v1.80.0)

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.8.1
+version: 1.9.0
 appVersion: 1.80.0
 
 home: https://lakefs.io

--- a/charts/lakefs/templates/_helpers.tpl
+++ b/charts/lakefs/templates/_helpers.tpl
@@ -82,11 +82,14 @@ Define which repository to use according to the following:
 {{- end }}
 
 {{/*
-Select the image tag based on the enterprise flag. Community and enterprise
-tags are decoupled to allow independent release cadences.
+Select the image tag. An explicit .Values.image.tag wins (back-compat override).
+Otherwise pick community or enterprise tag based on the enterprise flag so each
+variant can release on its own cadence.
 */}}
 {{- define "lakefs.tag" -}}
-{{- if (.Values.enterprise).enabled }}
+{{- if .Values.image.tag }}
+{{- .Values.image.tag }}
+{{- else if (.Values.enterprise).enabled }}
 {{- required "image.enterprise.tag is required when enterprise.enabled is true" (((.Values.image).enterprise).tag) }}
 {{- else }}
 {{- required "image.community.tag is required" (((.Values.image).community).tag) }}

--- a/charts/lakefs/templates/_helpers.tpl
+++ b/charts/lakefs/templates/_helpers.tpl
@@ -81,6 +81,18 @@ Define which repository to use according to the following:
 {{- end }}
 {{- end }}
 
+{{/*
+Select the image tag based on the enterprise flag. Community and enterprise
+tags are decoupled to allow independent release cadences.
+*/}}
+{{- define "lakefs.tag" -}}
+{{- if (.Values.enterprise).enabled }}
+{{- required "image.enterprise.tag is required when enterprise.enabled is true" (((.Values.image).enterprise).tag) }}
+{{- else }}
+{{- required "image.community.tag is required" (((.Values.image).community).tag) }}
+{{- end }}
+{{- end }}
+
 {{- define "lakefs.checkDeprecated" -}}
 {{- if .Values.fluffy -}}
 {{- fail "Fluffy configuration detected. Please migrate to lakeFS Enterprise auth configuration and use treeverse/lakefs-enterprise docker image. See migration guide: https://docs.lakefs.io/latest/enterprise/upgrade/#kubernetes-migrating-with-helm-from-fluffy-to-new-lakefs-enterprise." -}}

--- a/charts/lakefs/templates/deployment.yaml
+++ b/charts/lakefs/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ include "lakefs.repository" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "lakefs.repository" . }}:{{ include "lakefs.tag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -6,6 +6,10 @@ replicaCount: 1
 
 image:
   pullPolicy: IfNotPresent
+  community:
+    tag: "1.80.0"
+  enterprise:
+    tag: "1.80.0"
   privateRegistry:
     enabled: false
     secretToken: null


### PR DESCRIPTION
## This is a temporary WA until we decide on a more permanent solution for the charts!


Closes #391

## Summary
- Replace `.Values.image.tag | default .Chart.AppVersion` with a new `lakefs.tag` helper that picks `image.enterprise.tag` when `enterprise.enabled` is true, otherwise `image.community.tag`.
- Fail loudly (no silent `Chart.AppVersion` fallback) if the selected tag is unset.
- Bump chart to 1.9.0 and update CHANGELOG.

## Test plan
- [x] `helm template` with defaults → `treeverse/lakefs:1.80.0`
- [x] `helm template --set enterprise.enabled=true` → `treeverse/lakefs-enterprise:1.80.0`
- [x] Overriding `image.community.tag` / `image.enterprise.tag` independently produces the expected image
- [x] Unsetting the selected tag errors with a clear `required` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)