### PR TITLE
mds: run on lakefs-enterprise image via `lakefs mds run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 1.10.0
 :new: What's new:
-- MDS now runs on the `treeverse/lakefs-enterprise` image via `lakefs mds run` and uses the `metadata_search` config schema. Override `mds.image.repository`/`mds.image.tag` and `mds.args` (and re-add the legacy `metadata_settings`/`lakefs` config) to roll back to the standalone `treeverse/mds` container.
+- MDS now runs on the `treeverse/lakefs-enterprise` image via `lakefs mds run` and uses the `metadata_search` config schema.
 - Added `mds.command` and `mds.args` for overriding the MDS container entrypoint and arguments.
 
 # 1.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 1.10.0
+:new: What's new:
+- MDS now runs on the `treeverse/lakefs-enterprise` image via `lakefs mds run` and uses the `metadata_search` config schema. Override `mds.image.repository`/`mds.image.tag` and `mds.args` (and re-add the legacy `metadata_settings`/`lakefs` config) to roll back to the standalone `treeverse/mds` container.
+- Added `mds.command` and `mds.args` for overriding the MDS container entrypoint and arguments.
+
 # 1.9.3
 :new: What's new:
 - Update lakeFS community version to [1.81.0](https://github.com/treeverse/lakeFS/releases/tag/v1.81.0/)

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.9.3
+version: 1.10.0
 appVersion: 1.83.0
 
 home: https://lakefs.io

--- a/charts/lakefs/templates/mds/_mds.tpl
+++ b/charts/lakefs/templates/mds/_mds.tpl
@@ -29,6 +29,28 @@ app: {{ include "lakefs.name" . }}-mds
 {{- end }}
 
 {{/*
+MDS image repository. Defaults to the lakeFS Enterprise image, which ships
+the `lakefs mds` subcommand. To roll back to the legacy standalone MDS
+container, override `mds.image.repository` (and typically `mds.image.tag`
+and `mds.args` / `mds.command`) in values.
+*/}}
+{{- define "mds.repository" -}}
+{{- default "treeverse/lakefs-enterprise" .Values.mds.image.repository -}}
+{{- end }}
+
+{{/*
+MDS image tag. Explicit `mds.image.tag` wins; otherwise reuse the chart's
+enterprise tag so the MDS pod tracks the lakeFS server version by default.
+*/}}
+{{- define "mds.tag" -}}
+{{- if .Values.mds.image.tag -}}
+{{- .Values.mds.image.tag -}}
+{{- else -}}
+{{- required "image.enterprise.tag is required when mds.enabled is true and mds.image.tag is unset" (((.Values.image).enterprise).tag) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 MDS volumes
 */}}
 {{- define "mds.volumes" -}}

--- a/charts/lakefs/templates/mds/deployment.yaml
+++ b/charts/lakefs/templates/mds/deployment.yaml
@@ -36,11 +36,16 @@ spec:
       {{- end }}
       containers:
         - name: mds
-          args:
-            - --config
-            - /app/config.yaml
-          image: "{{ .Values.mds.image.repository }}:{{ .Values.mds.image.tag }}"
+          image: "{{ include "mds.repository" . }}:{{ include "mds.tag" . }}"
           imagePullPolicy: {{ .Values.mds.image.pullPolicy }}
+          {{- with .Values.mds.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.mds.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080
@@ -53,14 +58,8 @@ spec:
           livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          env:
-            # TODO(mds): Remove this workaround once the MDS image installs
-            # packages globally instead of under the arktika user home directory.
-            # When securityContext sets a different runAsUser, Python cannot find
-            # packages installed in /home/arktika/.local/lib/python3.13/site-packages.
-            - name: PYTHONPATH
-              value: /home/arktika/.local/lib/python3.13/site-packages
           {{- with .Values.mds.extraEnvVars }}
+          env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -129,13 +129,6 @@ mds:
   enabled: false
   image:
     pullPolicy: IfNotPresent
-    # Defaults to `treeverse/lakefs-enterprise` when unset (see templates/mds/_mds.tpl).
-    repository: ""
-    # Defaults to `image.enterprise.tag` when unset.
-    tag: ""
-  # Override the container ENTRYPOINT. Empty uses the image default
-  # (`/app/lakefs` for the lakeFS Enterprise image).
-  command: []
   # Args appended after the ENTRYPOINT. The default runs the metadata search
   # service on the lakeFS Enterprise image; override when rolling back to the
   # legacy MDS container (which expects only `--config /app/config.yaml`).

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -113,11 +113,37 @@ extraEnvVars:
 #   initialDelaySeconds: 5
 
 # https://docs.lakefs.io/latest/datamanagment/metadata-search/#configuration-reference
+#
+# MDS runs the metadata search service. The default image is
+# `treeverse/lakefs-enterprise`, invoked as `lakefs mds run`. To roll back to
+# the legacy standalone MDS container, override the image and args, e.g.:
+#   mds:
+#     image:
+#       repository: treeverse/mds
+#       tag: "0.2.1"
+#     args: ["--config", "/app/config.yaml"]
+#     extraEnvVars:
+#       - name: PYTHONPATH
+#         value: /home/arktika/.local/lib/python3.13/site-packages
 mds:
   enabled: false
   image:
     pullPolicy: IfNotPresent
-    repository: treeverse/mds
+    # Defaults to `treeverse/lakefs-enterprise` when unset (see templates/mds/_mds.tpl).
+    repository: ""
+    # Defaults to `image.enterprise.tag` when unset.
+    tag: ""
+  # Override the container ENTRYPOINT. Empty uses the image default
+  # (`/app/lakefs` for the lakeFS Enterprise image).
+  command: []
+  # Args appended after the ENTRYPOINT. The default runs the metadata search
+  # service on the lakeFS Enterprise image; override when rolling back to the
+  # legacy MDS container (which expects only `--config /app/config.yaml`).
+  args:
+    - mds
+    - run
+    - --config
+    - /app/config.yaml
   extraEnvVars: {}
   resources:
     # limits:
@@ -144,23 +170,28 @@ mds:
     # successThreshold: 4
     # timeoutSeconds: 1
     # initialDelaySeconds: 5
+  # Rendered verbatim into the MDS config file. The default schema below
+  # matches the lakeFS Enterprise `metadata_search` section; replace with the
+  # legacy MDS schema (`lakefs:` / `metadata_settings:` / `repositories:`)
+  # when rolling back to the standalone MDS image.
   config:
-    lakefs:
-      endpoint: "https://example.lakefs.io"
+    metadata_search:
+      lakefs_mds_endpoint: "https://example.lakefs.io"
       access_key_id: "AKIAIOSFOLEXAMPLE"
-      secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-    metadata_settings:
-      since: "1970-01-01T00:00:00+00"
-      max_commits: 100
-    repositories:
-      # example-repo-1:
-      #   branches:
-      #   - main
-      #   - dev
-      # example-repo-2:
-      #   branches:
-      #   - main
-      #   - feature-*
+      secret_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+      # period: 60s
+      # concurrency: 25
+      # max_commits: 1000
+      # since: "1970-01-01T00:00:00Z"
+      repositories: {}
+        # example-repo-1:
+        #   branches:
+        #     - main
+        #     - dev
+        # example-repo-2:
+        #   branches:
+        #     - main
+        #     - feature-*
 
 # https://docs.lakefs.io/latest/howto/mirroring/
 replication:


### PR DESCRIPTION
Closes #396

## Summary
- Switches the MDS deployment to the `treeverse/lakefs-enterprise` image and invokes it as `lakefs mds run`, replacing the legacy standalone Python MDS container.
- New `mds.repository` / `mds.tag` helpers: `mds.image.repository` defaults to `treeverse/lakefs-enterprise`, `mds.image.tag` falls back to `image.enterprise.tag` so the MDS pod tracks the lakeFS server version by default.
- New `mds.command` and `mds.args` values let users override the container ENTRYPOINT and arguments. Default `args: ["mds", "run", "--config", "/app/config.yaml"]` overrides the lakeFS image's `["run"]` CMD.
- Drops the Python-specific `PYTHONPATH` env workaround that was tied to the old MDS image.
- Refreshes the example `mds.config` to match the lakeFS Enterprise `metadata_search` schema.
- Bumps chart to `1.10.0` with CHANGELOG entry.

## Rollback (no chart edits required)
```yaml
mds:
  image:
    repository: treeverse/mds
    tag: "0.2.1"
  args: ["--config", "/app/config.yaml"]
  extraEnvVars:
    - name: PYTHONPATH
      value: /home/arktika/.local/lib/python3.13/site-packages
  config:
    lakefs: { endpoint: ..., access_key_id: ..., secret_access_key: ... }
    metadata_settings: { since: ..., max_commits: 100 }
    repositories: { ... }
```

## Test plan
- [ ] `helm lint charts/lakefs`
- [ ] `helm template charts/lakefs --set mds.enabled=true` renders the deployment with `image: treeverse/lakefs-enterprise:<image.enterprise.tag>` and `args: [mds, run, --config, /app/config.yaml]`, no `command:` field, no `PYTHONPATH` env.
- [ ] `helm template charts/lakefs --set mds.enabled=true --set mds.image.repository=treeverse/mds --set mds.image.tag=0.2.1 --set 'mds.args={--config,/app/config.yaml}'` renders the legacy image with the legacy args.
- [ ] Deploy to a cluster with a valid enterprise license and verify the MDS pod becomes ready and the `/health` endpoint responds.

https://claude.ai/code/session_01K7WeQ1doQLnWsXY2EEvGNR