### PR TITLE
Update lakeFS Enterprise version to 1.85.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.12.2
+:new: What's new:
+- Update lakeFS Enterprise version to [1.85.1](https://changelog.lakefs.io/lakefs-enterprise/1.85.1/)
+
 # 1.12.1
 :new: What's new:
 - Update lakeFS Enterprise version to [1.85.0](https://changelog.lakefs.io/lakefs-enterprise/1.85.0/)

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.12.1
-appVersion: 1.86.0
+version: 1.12.2
+appVersion: 1.86.1
 
 home: https://lakefs.io
 icon: https://lakefs.io/wp-content/uploads/2020/07/lake-fs-color-2.svg

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -9,7 +9,7 @@ image:
   community:
     tag: "1.81.1"
   enterprise:
-    tag: "1.85.0"
+    tag: "1.85.1"
   privateRegistry:
     enabled: false
     secretToken: null


### PR DESCRIPTION
Bumps the lakeFS Enterprise image to `1.85.1`.

- `values.yaml`: `image.enterprise.tag` → `1.85.1`
- `Chart.yaml`: chart `version` → `1.12.2`, `appVersion` → `1.86.1`
- `CHANGELOG.md`: add `1.12.2` entry

No chart-parameter or breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)