### PR TITLE
Update lakeFS Enterprise version to 1.86.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 1.12.3
+:new: What's new:
+- Update lakeFS Enterprise version to [1.86.0](https://changelog.lakefs.io/lakefs-enterprise/1.86.0/)
+  - Important note: lakeFS Enterprise 1.86.0 adds auth inverse secondary indices. Deployments with local RBAC data require a one-time KV migration (`lakefs migrate up`) before rolling out the new version — see the [release notes](https://changelog.lakefs.io/lakefs-enterprise/1.86.0/) for details.
+
 # 1.12.2
 :new: What's new:
 - Update lakeFS Enterprise version to [1.85.1](https://changelog.lakefs.io/lakefs-enterprise/1.85.1/)

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.12.2
-appVersion: 1.86.1
+version: 1.12.3
+appVersion: 1.87.0
 
 home: https://lakefs.io
 icon: https://lakefs.io/wp-content/uploads/2020/07/lake-fs-color-2.svg

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -9,7 +9,7 @@ image:
   community:
     tag: "1.81.1"
   enterprise:
-    tag: "1.85.1"
+    tag: "1.86.0"
   privateRegistry:
     enabled: false
     secretToken: null


### PR DESCRIPTION
Update `image.enterprise.tag` to 1.86.0, bump `appVersion` to 1.87.0 and chart `version` to 1.12.3.

Note: lakeFS Enterprise 1.86.0 requires a one-time KV migration for deployments with local RBAC data — see the [release notes](https://github.com/treeverse/lakeFS-Enterprise/releases/tag/v1.86.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)