### PR TITLE
Update lakeFS community version to 1.82.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.12.4
+:new: What's new:
+- Update lakeFS community version to [1.82.0](https://github.com/treeverse/lakeFS/releases/tag/v1.82.0/)
+
 # 1.12.3
 :new: What's new:
 - Update lakeFS Enterprise version to [1.86.0](https://changelog.lakefs.io/lakefs-enterprise/1.86.0/)

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.12.3
-appVersion: 1.87.0
+version: 1.12.4
+appVersion: 1.88.0
 
 home: https://lakefs.io
 icon: https://lakefs.io/wp-content/uploads/2020/07/lake-fs-color-2.svg

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   pullPolicy: IfNotPresent
   community:
-    tag: "1.81.1"
+    tag: "1.82.0"
   enterprise:
     tag: "1.86.0"
   privateRegistry:


### PR DESCRIPTION
Bumps the community lakeFS image to [1.82.0](https://github.com/treeverse/lakeFS/releases/tag/v1.82.0/).

- `image.community.tag`: 1.81.1 → 1.82.0
- Chart `version`: 1.12.3 → 1.12.4
- `appVersion`: 1.87.0 → 1.88.0
- CHANGELOG updated