### PR TITLE
lakeFS Enterprise docker registry is public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.12.6
+:books: Documentation:
+- Clarify that lakeFS Enterprise images are public and a private registry token is not required
+
 # 1.12.5
 :new: What's new:
 - Update lakeFS Enterprise version to [1.87.0](https://changelog.lakefs.io/lakefs-enterprise/1.87.0/)

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.12.5
+version: 1.12.6
 appVersion: 1.89.0
 
 home: https://lakefs.io

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -11,6 +11,8 @@ image:
   enterprise:
     tag: "1.87.0"
   privateRegistry:
+    # Optional. lakeFS Enterprise images are public, so no token is required.
+    # Only needed when mirroring the images into your own private registry.
     enabled: false
     secretToken: null
     secretName: null

--- a/examples/lakefs/enterprise/ldap-enterprise.yaml
+++ b/examples/lakefs/enterprise/ldap-enterprise.yaml
@@ -14,10 +14,12 @@ enterprise:
       enabled: true
       bindPassword: <ldap bind password>
 
-image:
-  privateRegistry:
-    enabled: true
-    secretToken: <dockerhub-token>
+# lakeFS Enterprise images are publicly available - no private registry token is needed.
+# Only configure privateRegistry if you mirror the images into your own private registry:
+# image:
+#   privateRegistry:
+#     enabled: true
+#     secretToken: <dockerhub-token>
 
 lakefsConfig: |
   blockstore:

--- a/examples/lakefs/enterprise/oidc-enterprise.yaml
+++ b/examples/lakefs/enterprise/oidc-enterprise.yaml
@@ -15,10 +15,12 @@ enterprise:
       # secret given by the OIDC provider (e.g auth0, Okta, etc)
       client_secret: <oidc-client-secret>
 
-image:
-  privateRegistry:
-    enabled: true
-    secretToken: <dockerhub-token>
+# lakeFS Enterprise images are publicly available - no private registry token is needed.
+# Only configure privateRegistry if you mirror the images into your own private registry:
+# image:
+#   privateRegistry:
+#     enabled: true
+#     secretToken: <dockerhub-token>
 
 lakefsConfig: |
   blockstore:

--- a/examples/lakefs/enterprise/saml-enterprise.yaml
+++ b/examples/lakefs/enterprise/saml-enterprise.yaml
@@ -23,10 +23,12 @@ enterprise:
           ...
           -----END PRIVATE KEY-----
 
-image:
-  privateRegistry:
-    enabled: true
-    secretToken: <dockerhub-token>
+# lakeFS Enterprise images are publicly available - no private registry token is needed.
+# Only configure privateRegistry if you mirror the images into your own private registry:
+# image:
+#   privateRegistry:
+#     enabled: true
+#     secretToken: <dockerhub-token>
 
 lakefsConfig: |
   blockstore:


### PR DESCRIPTION
The lakeFS Enterprise images (`treeverse/lakefs-enterprise`, `treeverse/replication`) are public on Docker Hub, so a private-registry token / `imagePullSecret` is no longer required to pull them.

This updates the docs/examples so users aren't told to set up a token they don't need. `image.privateRegistry` stays available (commented out) for anyone mirroring images into their own private registry.

## Changes
- `examples/lakefs/enterprise/{oidc,ldap,saml}-enterprise.yaml` — comment out the `image.privateRegistry` block with a note that the images are public.
- `charts/lakefs/values.yaml` — note that `privateRegistry` is optional.