### PR TITLE
Update lakeFS Enterprise version to 1.87.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.12.5
+:new: What's new:
+- Update lakeFS Enterprise version to [1.87.0](https://changelog.lakefs.io/lakefs-enterprise/1.87.0/)
+
 # 1.12.4
 :new: What's new:
 - Update lakeFS community version to [1.82.0](https://github.com/treeverse/lakeFS/releases/tag/v1.82.0/)

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.12.4
-appVersion: 1.88.0
+version: 1.12.5
+appVersion: 1.89.0
 
 home: https://lakefs.io
 icon: https://lakefs.io/wp-content/uploads/2020/07/lake-fs-color-2.svg

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -9,7 +9,7 @@ image:
   community:
     tag: "1.82.0"
   enterprise:
-    tag: "1.86.0"
+    tag: "1.87.0"
   privateRegistry:
     enabled: false
     secretToken: null


### PR DESCRIPTION
Releases lakeFS Enterprise **1.87.0** in the Helm chart, following the established version-bump pattern.

## Changes
- `charts/lakefs/values.yaml`: enterprise image tag `1.86.0` → `1.87.0`
- `charts/lakefs/Chart.yaml`: `version` `1.12.4` → `1.12.5`, `appVersion` `1.88.0` → `1.89.0`
- `CHANGELOG.md`: new `# 1.12.5` entry linking to the [1.87.0 release notes](https://changelog.lakefs.io/lakefs-enterprise/1.87.0/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MacYf23EyJbxt1z6yDocK4)_