### PR TITLE
Auto-approve enterprise release version-bump PRs

### DIFF
--- a/.github/workflows/auto-approve-release-pr.yaml
+++ b/.github/workflows/auto-approve-release-pr.yaml
@@ -1,0 +1,27 @@
+# Approves chart version-bump PRs opened by the lakeFS-Enterprise release
+# automation (treeverse-ci-bot). The automation enables auto-merge when it
+# opens the PR, so with this approval the PR merges as soon as the required
+# checks pass, and the merge releases the new chart version.
+
+name: Auto-approve release PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  approve:
+    if: >-
+      github.event.pull_request.user.login == 'treeverse-ci-bot[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'auto-release/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Approve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr review --approve "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"


### PR DESCRIPTION
Part of treeverse/lakeFS-Enterprise#3021.

On a lakeFS Enterprise release, a workflow in lakeFS-Enterprise opens a chart version-bump PR here as `treeverse-ci-bot` and enables auto-merge on it (using the app token, so the eventual merge still triggers the chart release workflow). This new workflow supplies the required approval for those PRs, so they merge as soon as the required checks (`lint`, `check-changelog`) pass — releasing the new chart.

The approval is gated on all of:
- PR author is `treeverse-ci-bot[bot]`
- head branch starts with `auto-release/`
- head branch is in this repository (not a fork)

Repo settings this relies on (already in place): auto-merge enabled, Actions allowed to approve PRs, and branch protection on `master` requiring the `lint`/`check-changelog` checks plus one approving review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)