### PR TITLE
Bump replication to 0.1.18 (chart 1.12.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.12.15
+:new: What's new:
+- Update the replication (Transactional Mirroring) image to [0.1.18](https://docs.lakefs.io/releases/replication/0.1.18/)
+
 # 1.12.14
 :new: What's new:
 - Update lakeFS community version to [1.84.0](https://github.com/treeverse/lakeFS/releases/tag/v1.84.0)

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.12.14
+version: 1.12.15
 appVersion: 1.96.0
 home: https://lakefs.io
 icon: https://lakefs.io/wp-content/uploads/2020/07/lake-fs-color-2.svg

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -181,7 +181,7 @@ replication:
   enabled: false
   image:
     repository: treeverse/replication
-    tag: 0.1.17
+    tag: 0.1.18
     pullPolicy: IfNotPresent
   port: 8008
   resources: {}


### PR DESCRIPTION
Updates the replication (Transactional Mirroring) image to 0.1.18, which fixes destination branches being deleted after a failed source branch listing, and same-name mirror recreation deadlocking on stale promotion requests (treeverse/lakeFS-Enterprise#3041, treeverse/lakeFS-Enterprise#3040).

🤖 Generated with [Claude Code](https://claude.com/claude-code)