### PR TITLE
lakefs: give the SAML certificates their own volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.12.23
+:bug: Bugs fixed:
+- Mount the SAML certificates from their own volume, so SAML can be enabled on a licensed installation
+
 # 1.12.22
 :new: What's new:
 - Update lakeFS Enterprise version to [1.95.0](https://docs.lakefs.io/releases/lakefs-enterprise/1.95.0/)

--- a/charts/lakefs/Chart.yaml
+++ b/charts/lakefs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lakefs
 description: A Helm chart for running LakeFS on Kubernetes
 type: application
-version: 1.12.22
+version: 1.12.23
 appVersion: 1.102.0
 home: https://lakefs.io
 icon: https://lakefs.io/wp-content/uploads/2020/07/lake-fs-color-2.svg

--- a/charts/lakefs/templates/_env.tpl
+++ b/charts/lakefs/templates/_env.tpl
@@ -125,7 +125,7 @@ envFrom:
 {{- end }}
 {{- end }}
 {{- if (((.Values.enterprise).auth).saml).enabled }}
-- name: secret-volume-license-token
+- name: saml-certificates
   secret:
     secretName: saml-certificates
 {{- end }}

--- a/charts/lakefs/templates/deployment.yaml
+++ b/charts/lakefs/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
               mountPath: "/lakefs/data"
           {{- end }}
           {{- if (((.Values.enterprise).auth).saml).enabled }}
-            - name: secret-volume-license-token
+            - name: saml-certificates
               readOnly: true
               mountPath: /etc/saml_certs/
           {{- end }}


### PR DESCRIPTION
Enabling SAML on a licensed installation cannot deploy: the pod declares two volumes named `secret-volume-license-token`.

```
$ helm template t charts/lakefs -f config.yaml \
    --set enterprise.enabled=true --set image.enterprise.tag=dev \
    --set secrets.licenseContents=fake-license \
    --set enterprise.auth.saml.enabled=true --set enterprise.auth.saml.createCertificateSecret=true \
    --set enterprise.auth.saml.certificate.samlRsaPublicCert=CERT \
    --set enterprise.auth.saml.certificate.samlRsaPrivateKey=KEY

volumes: ['config-volume', 'secret-volume-license-token', 'secret-volume-license-token']
    secret-volume-license-token -> t-lakefs            # the license secret
    secret-volume-license-token -> saml-certificates
mounts: [('secret-volume-license-token', '/etc/saml_certs/'),
         ('secret-volume-license-token', '/etc/lakefs/license.tkn')]
```

`spec.volumes[*].name` must be unique, so the API server rejects the Deployment. Even accepted, both mounts point at one volume, so the certificate paths in `LAKEFS_AUTH_PROVIDERS_SAML_SP_X509_*_PATH` would resolve against the license secret.

The certificates now use a `saml-certificates` volume, matching the secret `secret.yaml` creates. After the change, the same command renders unique names and the right mapping:

```
volumes: ['config-volume', 'secret-volume-license-token', 'saml-certificates']
mounts: [('config-volume', '/etc/lakefs/config.yaml'),
         ('saml-certificates', '/etc/saml_certs/'),
         ('secret-volume-license-token', '/etc/lakefs/license.tkn')]
```

An installation without SAML renders exactly as before. No values change, so nothing to migrate.

Found while adding a SAML setup to the lakeFS-Enterprise DevEnv (treeverse/lakeFS-Enterprise#3035), which is blocked on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Chart version bumped to 1.12.23 with a `CHANGELOG.md` entry, following the convention of other change PRs (e.g. #415). `helm lint` passes and the fix renders correctly on the current master.