### PR TITLE
Add commonLabels and podLabels support to the lakeFS chart

### DIFF
--- a/charts/lakefs/templates/_helpers.tpl
+++ b/charts/lakefs/templates/_helpers.tpl
@@ -41,6 +41,9 @@ helm.sh/chart: {{ include "lakefs.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -120,6 +123,9 @@ helm.sh/chart: {{ include "lakefs.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -150,6 +156,9 @@ helm.sh/chart: {{ include "lakefs.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/lakefs/templates/audit/cronjob.yaml
+++ b/charts/lakefs/templates/audit/cronjob.yaml
@@ -17,6 +17,9 @@ spec:
         metadata:
           labels:
             {{- include "audit.selectorLabels" . | nindent 12 }}
+            {{- with .Values.auditLog.maintenance.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.auditLog.maintenance.podAnnotations }}
           annotations:
             {{- toYaml . | nindent 12 }}

--- a/charts/lakefs/templates/configmap.yaml
+++ b/charts/lakefs/templates/configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "lakefs.fullname" . }}
+  labels:
+    {{- include "lakefs.labels" . | nindent 4 }}
 {{- with .Values.lakefsConfig }}
 data:
   config.yaml:

--- a/charts/lakefs/templates/deployment.yaml
+++ b/charts/lakefs/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
     {{- end }}
       labels:
         {{- include "lakefs.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if (.Values.image.privateRegistry).enabled }}
       imagePullSecrets:

--- a/charts/lakefs/templates/mds/_mds.tpl
+++ b/charts/lakefs/templates/mds/_mds.tpl
@@ -16,6 +16,9 @@ helm.sh/chart: {{ include "lakefs.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/lakefs/templates/mds/deployment.yaml
+++ b/charts/lakefs/templates/mds/deployment.yaml
@@ -20,6 +20,9 @@ spec:
       {{- end }}
       labels:
         {{- include "mds.selectorLabels" . | nindent 8 }}
+        {{- with .Values.mds.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.image.privateRegistry.enabled }}
       imagePullSecrets:

--- a/charts/lakefs/templates/replication/deployment.yaml
+++ b/charts/lakefs/templates/replication/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         {{- end }}
       labels:
         {{- include "replication.selectorLabels" . | nindent 8 }}
+        {{- with .Values.replication.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.replication.serviceAccountName }}
       serviceAccountName: {{ .Values.replication.serviceAccountName }}

--- a/charts/lakefs/templates/secret.yaml
+++ b/charts/lakefs/templates/secret.yaml
@@ -45,6 +45,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: saml-certificates
+  labels:
+    {{- include "lakefs.labels" . | nindent 4 }}
 data:
   rsa_saml_public.pem: '{{ .Values.enterprise.auth.saml.certificate.samlRsaPublicCert | b64enc }}'
   rsa_saml_private.key: '{{ .Values.enterprise.auth.saml.certificate.samlRsaPrivateKey | b64enc }}'
@@ -57,6 +59,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: docker-registry
+  labels:
+    {{- include "lakefs.labels" . | nindent 4 }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "lakefs.dockerConfigJson" . }}

--- a/charts/lakefs/values.yaml
+++ b/charts/lakefs/values.yaml
@@ -17,6 +17,10 @@ image:
     secretName: null
 nameOverride: ""
 fullnameOverride: ""
+# Labels applied to every resource this chart renders (Deployments, Services,
+# ConfigMaps, Secrets, ServiceAccount, Ingress, CronJob), in addition to the
+# chart's standard labels.
+commonLabels: {}
 ingress:
   enabled: false
   annotations: {}
@@ -37,6 +41,8 @@ ingress:
   #    hosts:
   #      - chart-example.local
 podAnnotations: {}
+# Extra labels applied to lakeFS pods, in addition to the chart's selector labels.
+podLabels: {}
 jobPodAnnotations:
   sidecar.istio.io/inject: "false"
 deployment:
@@ -129,6 +135,8 @@ mds:
   extraEnvVars: {}
   # Name of an existing secret to mount as envFrom on the MDS container.
   extraEnvVarsSecret: null
+  # Extra labels applied to the MDS pod, in addition to its selector labels.
+  podLabels: {}
   resources:
   # limits:
   #   cpu: 500m
@@ -186,6 +194,8 @@ replication:
   port: 8008
   resources: {}
   podAnnotations: {}
+  # Extra labels applied to the replication pod, in addition to its selector labels.
+  podLabels: {}
   extraEnvVars: []
   extraEnvVarsSecret: null
   serviceAccountName: ""
@@ -284,6 +294,8 @@ auditLog:
     extraArgs: []
     extraEnvVars: []
     podAnnotations: {}
+    # Extra labels applied to the audit maintenance CronJob's pod, in addition to its selector labels.
+    podLabels: {}
     resources: {}
     nodeSelector: {}
     tolerations: []


### PR DESCRIPTION
## Summary
- Adds a global `commonLabels` value merged into every rendered resource's `metadata.labels` (Deployment, Service, ConfigMap, Secret, ServiceAccount, Ingress, CronJob — across the main chart and the mds/replication/audit sub-components).
- Adds `podLabels` (plus per-component `mds.podLabels`, `replication.podLabels`, `auditLog.maintenance.podLabels`) merged into pod template `metadata.labels`, mirroring the existing `podAnnotations` pattern. Kept separate from `selectorLabels`/`matchLabels` so selectors stay immutable.
- Fixes two gaps found along the way: the main `ConfigMap` had no `labels` block at all, and the SAML-certificate / docker-registry `Secret`s were unlabeled — both now get the standard chart labels (and thus `commonLabels`).

## Test plan
- [x] `helm lint charts/lakefs`
- [x] `helm template charts/lakefs` with default values renders cleanly
- [x] `helm template` with `commonLabels`/`podLabels` set (plus per-component `podLabels`) and `mds.enabled`, `replication.enabled`, `enterprise.enabled`, `auditLog.enabled`/`auditLog.maintenance.cronJob` all `true` — confirmed `commonLabels` lands on every resource and `podLabels` lands on every pod template, while `spec.selector.matchLabels` is untouched
- [x] `helm template` against all three `charts/lakefs/ci/*.yaml` value files